### PR TITLE
fix: 9 mutates CLI DX issues (incl. one breaking change)

### DIFF
--- a/packages/cli/scripts/gen-commands/emit-handler.ts
+++ b/packages/cli/scripts/gen-commands/emit-handler.ts
@@ -56,14 +56,14 @@ function renderHandlerBody(c: Classified): string {
   return session.withActiveProject(() => {
     const fn = ${c.coreName} as unknown as (...args: unknown[]) => unknown;
     const result = fn(file, p.data);
-    return { ok: true, result };
+    return result;
   });`;
     case 'query':
       return `  return session.withActiveProject(() => {
     const query = (p.target?.filter ?? p.data ?? undefined) as never;
     const fn = ${c.coreName} as unknown as (q?: unknown) => unknown;
     const result = fn(query);
-    return { ok: true, result: mintNodeRefs(session, result as unknown) };
+    return mintNodeRefs(session, result as unknown);
   });`;
     case 'nodes':
       return `  return session.withActiveProject(() => {
@@ -77,7 +77,7 @@ function renderHandlerBody(c: Classified): string {
     }
     const fn = ${c.coreName} as unknown as (...args: unknown[]) => unknown;
     const result = fn(declarations, p.data);
-    return { ok: true, result };
+    return result;
   });`;
     case 'declarations-editor':
       return `  return session.withActiveProject(() => {
@@ -93,12 +93,12 @@ function renderHandlerBody(c: Classified): string {
     const editor = (structure: Record<string, unknown>) => ({ ...structure, ...overrides });
     const fn = ${c.coreName} as unknown as (...args: unknown[]) => unknown;
     const result = fn(declarations, editor);
-    return { ok: true, result };
+    return result;
   });`;
     case 'no-params':
       return `  return session.withActiveProject(() => {
     const result = (${c.coreName} as () => unknown)();
-    return { ok: true, result };
+    return result;
   });`;
   }
 }

--- a/packages/cli/skills/core.md
+++ b/packages/cli/skills/core.md
@@ -124,7 +124,7 @@ file-stat cache. Sessions are keyed by the absolute project root.
   to point at the project that actually lists source files. When no
   tsconfig is found at all, the session falls back to globbing
   `**/*.{ts,tsx}` under the root, excluding `node_modules`, `dist`,
-  `.git`, `tmp`, `coverage`.
+  `build`, `out`, `.next`, `.nx`, `.git`, `tmp`, `coverage`.
 - **Idle timeout.** Each session has an idle timeout, defaulting to
   **600 seconds** since the last RPC. The timeout is overridable
   via the `MUTATES_IDLE_TIMEOUT` environment variable (read by the

--- a/packages/cli/skills/core.md
+++ b/packages/cli/skills/core.md
@@ -61,7 +61,7 @@ A minimal end-to-end transcript looks like this:
 
 ```bash
 mutates open --root /repo --json
-# {"sessionId":"01HX...","root":"/repo"}
+# {"sessionId":"01HX...","tsconfig":"/repo/tsconfig.json","idleTimeoutMs":600000}
 
 mutates snapshot /repo/src/app.ts --json
 # {"entries":[{"kind":"class","name":"AppService","ref":"@n0"}, ...]}
@@ -116,6 +116,15 @@ file-stat cache. Sessions are keyed by the absolute project root.
   any subcommand with `--root /path/to/repo` (or just running it
   inside the repo) is enough to wake a daemon and spin up the
   session. No explicit `open` is required.
+- **tsconfig resolution.** If `<root>/tsconfig.json` exists, ts-morph
+  loads files from it. If it's a **solution-style** tsconfig (empty
+  `files`/`include` with non-empty `references`), `open` returns
+  `INVALID_INPUT` instead of silently giving you an empty session —
+  pass `mutates open --tsconfig <leaf-tsconfig>` (e.g. `tsconfig.lib.json`)
+  to point at the project that actually lists source files. When no
+  tsconfig is found at all, the session falls back to globbing
+  `**/*.{ts,tsx}` under the root, excluding `node_modules`, `dist`,
+  `.git`, `tmp`, `coverage`.
 - **Idle timeout.** Each session has an idle timeout, defaulting to
   **600 seconds** since the last RPC. The timeout is overridable
   via the `MUTATES_IDLE_TIMEOUT` environment variable (read by the
@@ -124,12 +133,15 @@ file-stat cache. Sessions are keyed by the absolute project root.
   timeout entirely; use that sparingly.
 - **Listing.** To enumerate live sessions for a root, run
   `mutates sessions list --root <root> --json`. Output is a JSON
-  array of `{ id, root, openedAt, lastActivityAt }`.
+  array of `{ id, root, ageMs, unsavedFiles }`.
 - **Closing.** `mutates close --all --root <root>` closes every
-  session for that root; `mutates close <sessionId>` closes one by
-  id. When the daemon process itself exits (idle timeout fires,
-  explicit kill, host reboot), all in-memory state is gone —
-  anything you didn't `save` is lost.
+  session for that root; `mutates close --session <sessionId>` closes
+  one by id. `--all` also tells the daemon to shut down, so the socket
+  and lockfile clean up immediately rather than waiting for the idle
+  timer. If `--all` finds nothing to close, the response is
+  `{ closed: [], noop: true }`. When the daemon process itself exits
+  (idle timeout fires, explicit kill, host reboot), all in-memory state
+  is gone — anything you didn't `save` is lost.
 - **Multiple sessions per root.** Each `open` call mints a new
   session, so several agents can drive the same repo
   independently without trampling each other's refs. They share
@@ -141,8 +153,11 @@ file-stat cache. Sessions are keyed by the absolute project root.
 Every category exposes some combination of `get-*`, `add-*`, `edit-*`,
 and `remove-*` verbs. Run `mutates schema` for the full JSON-Schema
 payload of every op, or `mutates schema --op <opName>` for one. The
-list below is one line per category — for exhaustive shapes use the
-schema command.
+catalogue also covers the hand-written core ops (`snapshot`, `find`,
+`diff`, `save`, `reload`, `listFiles`, `session.open`,
+`session.close`, `session.list`) so you can introspect their param
+shapes the same way. The list below is one line per category — for
+exhaustive shapes use the schema command.
 
 - **classes** — top-level `class` declarations.
 - **methods** — methods on any host (class or object literal),
@@ -170,6 +185,7 @@ schema command.
 - **interfaces** — interface declarations (members are edited
   through the same payload).
 - **enums** — enum declarations.
+- **type-aliases** — top-level `type X = …` aliases.
 - **variables** — `const` / `let` / `var` declarations (one
   statement at a time, even if the statement contains multiple
   bindings).

--- a/packages/cli/src/commands/core/close.spec.ts
+++ b/packages/cli/src/commands/core/close.spec.ts
@@ -1,0 +1,87 @@
+import { runCommand } from 'citty';
+
+import { connectClient } from '../../client/rpc-client';
+import close from './close';
+
+vi.mock('../../client/rpc-client', () => ({
+  connectClient: vi.fn(),
+}));
+
+interface FakeConn {
+  call: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+}
+
+function makeFakeConn(calls: Record<string, unknown>): FakeConn {
+  return {
+    call: vi.fn(async (method: string) => calls[method] ?? null),
+    close: vi.fn(async () => undefined),
+  };
+}
+
+async function capture<T>(
+  fn: () => Promise<T>,
+): Promise<{ stdout: string; stderr: string; value: T }> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  let stdout = '';
+  let stderr = '';
+  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+    stdout += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+    stderr += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    const value = await fn();
+    return { stdout, stderr, value };
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+}
+
+describe('mutates close --all', () => {
+  beforeEach(() => {
+    vi.mocked(connectClient).mockReset();
+  });
+
+  it('returns {closed:[], noop:true} JSON when no live sessions exist', async () => {
+    const fake = makeFakeConn({ 'session.list': [], 'daemon.shutdown': null });
+    vi.mocked(connectClient).mockResolvedValue(fake as never);
+
+    const run = await capture(() =>
+      runCommand(close, { rawArgs: ['--all', '--root', '/tmp/none', '--json'] }),
+    );
+    const payload = JSON.parse(run.stdout.trim());
+    expect(payload).toEqual({ closed: [], noop: true });
+  });
+
+  it('prints a friendly text message when no live sessions exist', async () => {
+    const fake = makeFakeConn({ 'session.list': [], 'daemon.shutdown': null });
+    vi.mocked(connectClient).mockResolvedValue(fake as never);
+
+    const run = await capture(() =>
+      runCommand(close, { rawArgs: ['--all', '--root', '/tmp/none'] }),
+    );
+    expect(run.stdout).toContain('no live sessions for /tmp/none');
+  });
+
+  it('closes every live session and omits noop when work was done', async () => {
+    const fake = makeFakeConn({
+      'session.list': [{ id: 'abc' }, { id: 'def' }],
+      'session.close': null,
+      'daemon.shutdown': null,
+    });
+    vi.mocked(connectClient).mockResolvedValue(fake as never);
+
+    const run = await capture(() =>
+      runCommand(close, { rawArgs: ['--all', '--root', '/tmp/x', '--json'] }),
+    );
+    const payload = JSON.parse(run.stdout.trim());
+    expect(payload.closed).toEqual(['abc', 'def']);
+    expect(payload.noop).toBeUndefined();
+  });
+});

--- a/packages/cli/src/commands/core/close.ts
+++ b/packages/cli/src/commands/core/close.ts
@@ -49,12 +49,14 @@ export default defineCommand({
       const conn = await connectClient({ root });
       try {
         const closed: string[] = [];
+        let noop = false;
         if (args.all) {
           const sessions = await conn.call<Array<{ id: string }>>('session.list', {});
           for (const s of sessions) {
             await conn.call('session.close', { sessionId: s.id });
             closed.push(s.id);
           }
+          noop = closed.length === 0;
           // `--all` is the user saying "I'm done with this daemon" — shut it
           // down so the lockfile and socket clean up immediately, instead
           // of leaving the daemon hanging until its idle timer fires.
@@ -69,7 +71,15 @@ export default defineCommand({
           await conn.call('session.close', { sessionId: args.session });
           closed.push(args.session);
         }
-        renderResult({ closed }, args.json ? 'json' : 'text');
+        const payload: { closed: string[]; noop?: boolean } = { closed };
+        if (noop) payload.noop = true;
+        if (args.json) {
+          renderResult(payload, 'json');
+        } else if (noop) {
+          renderResult(`no live sessions for ${root}`, 'text');
+        } else {
+          renderResult(payload, 'text');
+        }
       } finally {
         await conn.close();
       }

--- a/packages/cli/src/commands/core/open.ts
+++ b/packages/cli/src/commands/core/open.ts
@@ -22,6 +22,11 @@ export default defineCommand({
       type: 'string',
       description: 'Project root (defaults to cwd)',
     },
+    tsconfig: {
+      type: 'string',
+      description:
+        'Path to a leaf tsconfig (resolved from cwd, or absolute). Overrides <root>/tsconfig.json',
+    },
     json: {
       type: 'boolean',
       description: 'Print the response as JSON instead of text',
@@ -33,7 +38,9 @@ export default defineCommand({
     try {
       const conn = await connectClient({ root });
       try {
-        const result = await conn.call('session.open', { root });
+        const params: { root: string; tsconfig?: string } = { root };
+        if (args.tsconfig) params.tsconfig = resolve(args.tsconfig);
+        const result = await conn.call('session.open', params);
         renderResult(result, args.json ? 'json' : 'text');
       } finally {
         await conn.close();

--- a/packages/cli/src/commands/core/schema.spec.ts
+++ b/packages/cli/src/commands/core/schema.spec.ts
@@ -1,6 +1,7 @@
 import { runCommand } from 'citty';
 
 import { OP_SCHEMAS } from '../../generated/op-schemas';
+import { CORE_OP_SCHEMAS } from '../../proto/core-op-schemas';
 import schema from './schema';
 
 /**
@@ -82,9 +83,23 @@ describe('mutates schema command', () => {
     }
   });
 
-  it('OP_SCHEMAS is in sync with what the command emits', async () => {
+  it('OP_SCHEMAS plus CORE_OP_SCHEMAS is in sync with what the command emits', async () => {
     const run = await capture(() => runCommand(schema, { rawArgs: [] }));
     const out = JSON.parse(run.stdout.trim()) as { ops: Array<{ op: string }> };
-    expect(out.ops.length).toBe(Object.keys(OP_SCHEMAS).length);
+    expect(out.ops.length).toBe(
+      Object.keys(OP_SCHEMAS).length + Object.keys(CORE_OP_SCHEMAS).length,
+    );
+  });
+
+  it('exposes a schema for the hand-written snapshot core op', async () => {
+    const run = await capture(() => runCommand(schema, { rawArgs: ['--op', 'snapshot'] }));
+    const entry = JSON.parse(run.stdout.trim()) as {
+      op: string;
+      category: string;
+      schema: { type: string };
+    };
+    expect(entry.op).toBe('snapshot');
+    expect(entry.category).toBe('core');
+    expect(entry.schema.type).toBe('object');
   });
 });

--- a/packages/cli/src/commands/core/schema.ts
+++ b/packages/cli/src/commands/core/schema.ts
@@ -2,6 +2,7 @@ import { defineCommand } from 'citty';
 
 import { renderResult } from '../../client/output';
 import { OP_SCHEMAS } from '../../generated/op-schemas';
+import { CORE_OP_SCHEMAS } from '../../proto/core-op-schemas';
 
 /**
  * `mutates schema` — JSON-schema discovery for every generated op.
@@ -35,7 +36,7 @@ export default defineCommand({
   },
   run({ args }) {
     if (args.op) {
-      const entry = OP_SCHEMAS[args.op];
+      const entry = OP_SCHEMAS[args.op] ?? CORE_OP_SCHEMAS[args.op];
       if (!entry) {
         process.stderr.write(
           JSON.stringify({ code: 'NOT_FOUND', message: `unknown op "${args.op}"` }) + '\n',
@@ -47,9 +48,9 @@ export default defineCommand({
       return;
     }
 
-    const ops = Object.values(OP_SCHEMAS)
-      .slice()
-      .sort((a, b) => a.op.localeCompare(b.op));
+    const ops = [...Object.values(OP_SCHEMAS), ...Object.values(CORE_OP_SCHEMAS)].sort((a, b) =>
+      a.op.localeCompare(b.op),
+    );
     renderResult({ ops }, 'json');
   },
 });

--- a/packages/cli/src/daemon/dispatcher.ts
+++ b/packages/cli/src/daemon/dispatcher.ts
@@ -139,7 +139,8 @@ function errorResponse(
 
 const sessionOpenHandler: Handler = ({ manager }, params) => {
   const root = readStringParam(params, 'root', 'session.open');
-  const session = manager.open(root);
+  const tsconfig = readOptionalStringParam(params, 'tsconfig', 'session.open');
+  const session = manager.open(root, tsconfig);
   return {
     sessionId: session.id,
     tsconfig: session.tsconfig,
@@ -171,6 +172,19 @@ function readStringParam(params: unknown, key: string, method: string): string {
     throw new RpcErrorClass(
       ErrorCode.InvalidParams,
       `${method}: missing or invalid '${key}' param`,
+    );
+  }
+  return value;
+}
+
+function readOptionalStringParam(params: unknown, key: string, method: string): string | undefined {
+  if (params === null || typeof params !== 'object') return undefined;
+  const value = (params as Record<string, unknown>)[key];
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new RpcErrorClass(
+      ErrorCode.InvalidParams,
+      `${method}: invalid '${key}' param (expected non-empty string)`,
     );
   }
   return value;

--- a/packages/cli/src/daemon/handlers/find.ts
+++ b/packages/cli/src/daemon/handlers/find.ts
@@ -5,6 +5,7 @@ import {
   getFunctions,
   getImports,
   getInterfaces,
+  getTypeAliases,
   getVariables,
   type Node,
 } from '@mutates/core';
@@ -23,6 +24,7 @@ const FINDERS: Record<string, (query?: Record<string, unknown>) => Node[]> = {
   function: getFunctions as unknown as (q?: Record<string, unknown>) => Node[],
   interface: getInterfaces as unknown as (q?: Record<string, unknown>) => Node[],
   enum: getEnums as unknown as (q?: Record<string, unknown>) => Node[],
+  type: getTypeAliases as unknown as (q?: Record<string, unknown>) => Node[],
   variable: getVariables as unknown as (q?: Record<string, unknown>) => Node[],
   import: getImports as unknown as (q?: Record<string, unknown>) => Node[],
   export: getExports as unknown as (q?: Record<string, unknown>) => Node[],

--- a/packages/cli/src/daemon/session-manager.ts
+++ b/packages/cli/src/daemon/session-manager.ts
@@ -35,8 +35,8 @@ export class SessionManager {
     this.onIdle = opts.onIdle ?? (() => undefined);
   }
 
-  open(root: string): Session {
-    const session = new Session({ root });
+  open(root: string, tsconfig?: string): Session {
+    const session = new Session({ root, tsconfig });
     this.sessions.set(session.id, session);
     this.touch();
     return session;

--- a/packages/cli/src/generated/.manifest.json
+++ b/packages/cli/src/generated/.manifest.json
@@ -1,5 +1,5 @@
 {
-  "count": 66,
+  "count": 70,
   "ops": [
     {
       "op": "addAccessors",
@@ -114,6 +114,14 @@
       "command": "src/commands/generated/source-files/add.ts"
     },
     {
+      "op": "addTypeAliases",
+      "verb": "add",
+      "category": "type-aliases",
+      "targetShape": "pattern",
+      "handler": "src/daemon/handlers/generated/type-aliases/add.ts",
+      "command": "src/commands/generated/type-aliases/add.ts"
+    },
+    {
       "op": "addVariables",
       "verb": "add",
       "category": "variables",
@@ -224,6 +232,14 @@
       "targetShape": "declarations-editor",
       "handler": "src/daemon/handlers/generated/params/edit.ts",
       "command": "src/commands/generated/params/edit.ts"
+    },
+    {
+      "op": "editTypeAliases",
+      "verb": "edit",
+      "category": "type-aliases",
+      "targetShape": "declarations-editor",
+      "handler": "src/daemon/handlers/generated/type-aliases/edit.ts",
+      "command": "src/commands/generated/type-aliases/edit.ts"
     },
     {
       "op": "editVariables",
@@ -410,6 +426,14 @@
       "command": "src/commands/generated/source-files/get.ts"
     },
     {
+      "op": "getTypeAliases",
+      "verb": "get",
+      "category": "type-aliases",
+      "targetShape": "query",
+      "handler": "src/daemon/handlers/generated/type-aliases/get.ts",
+      "command": "src/commands/generated/type-aliases/get.ts"
+    },
+    {
       "op": "getVariables",
       "verb": "get",
       "category": "variables",
@@ -520,6 +544,14 @@
       "targetShape": "nodes",
       "handler": "src/daemon/handlers/generated/params/remove.ts",
       "command": "src/commands/generated/params/remove.ts"
+    },
+    {
+      "op": "removeTypeAliases",
+      "verb": "remove",
+      "category": "type-aliases",
+      "targetShape": "nodes",
+      "handler": "src/daemon/handlers/generated/type-aliases/remove.ts",
+      "command": "src/commands/generated/type-aliases/remove.ts"
     },
     {
       "op": "removeVariables",

--- a/packages/cli/src/integration/op-smoke.spec.ts
+++ b/packages/cli/src/integration/op-smoke.spec.ts
@@ -173,12 +173,10 @@ describe('op smoke test — every category', () => {
       });
       expect('result' in resp).toBe(true);
       // op handler shape: { ok, result: <handler-return>, mutated }.
-      // Generated handler shape: { ok, result: <mintedRefs> }.
-      const opResult = (resp as { result: { result: { result: unknown } } }).result;
-      const inner = (opResult.result as { ok: boolean; result: unknown }).result as Array<{
-        ref?: string;
-        name?: string;
-      }>;
+      // Generated handler now returns the minted-ref array directly.
+      const opResult = (resp as { result: { ok: boolean; result: unknown; mutated: string[] } })
+        .result;
+      const inner = opResult.result as Array<{ ref?: string; name?: string }>;
       // The handler returned successfully and the shape is a minted-ref
       // array. The exact contents depend on whether the active project
       // picked up the no-tsconfig source files, which is covered in

--- a/packages/cli/src/proto/core-op-schemas.ts
+++ b/packages/cli/src/proto/core-op-schemas.ts
@@ -23,7 +23,11 @@ function obj(
     type: 'object',
     properties,
     required,
-    additionalProperties: true,
+    // Core ops have a closed param surface — agents passing unknown
+    // keys are almost certainly making a mistake. Free-form sub-objects
+    // (e.g. `find`'s `query`) opt back in to additionalProperties:true
+    // on their own schema.
+    additionalProperties: false,
   };
 }
 

--- a/packages/cli/src/proto/core-op-schemas.ts
+++ b/packages/cli/src/proto/core-op-schemas.ts
@@ -1,0 +1,147 @@
+import type { OpSchema } from '../generated/op-schemas';
+
+/**
+ * JSON Schemas for the hand-written "core" ops that the codegen does not
+ * touch (everything that isn't `add*` / `edit*` / `remove*` / `get*`).
+ *
+ * Shape mirrors the entries produced by `scripts/gen-commands/emit-schema.ts`
+ * so `mutates schema` can merge both maps and present a single, uniform
+ * catalogue to agents. `targetShape` is set to a free-form label that
+ * describes the param structure — these ops don't take the standard
+ * `{ target, data }` envelope.
+ */
+const DRAFT = 'https://json-schema.org/draft/2020-12/schema';
+
+function obj(
+  title: string,
+  properties: Record<string, unknown>,
+  required: string[] = [],
+): Record<string, unknown> {
+  return {
+    $schema: DRAFT,
+    title,
+    type: 'object',
+    properties,
+    required,
+    additionalProperties: true,
+  };
+}
+
+const sessionId = { type: 'string', description: 'Session id minted by session.open' };
+const filePath = { type: 'string', description: 'Absolute file path' };
+
+export const CORE_OP_SCHEMAS: Record<string, OpSchema> = {
+  'session.open': {
+    op: 'session.open',
+    verb: 'open',
+    category: 'session',
+    targetShape: 'session-params',
+    schema: obj(
+      'session.open',
+      {
+        root: { type: 'string', description: 'Project root (absolute path)' },
+        tsconfig: {
+          type: 'string',
+          description:
+            'Optional path to a leaf tsconfig (absolute or relative to root). Overrides <root>/tsconfig.json',
+        },
+      },
+      ['root'],
+    ),
+  },
+  'session.close': {
+    op: 'session.close',
+    verb: 'close',
+    category: 'session',
+    targetShape: 'session-params',
+    schema: obj('session.close', { sessionId }, ['sessionId']),
+  },
+  'session.list': {
+    op: 'session.list',
+    verb: 'list',
+    category: 'session',
+    targetShape: 'no-params',
+    schema: obj('session.list', {}),
+  },
+  snapshot: {
+    op: 'snapshot',
+    verb: 'snapshot',
+    category: 'core',
+    targetShape: 'file-or-ref',
+    schema: obj(
+      'snapshot',
+      {
+        sessionId,
+        target: {
+          type: 'object',
+          properties: {
+            file: { ...filePath, description: 'Absolute file path to walk' },
+            ref: { type: 'string', description: 'Parent ref (@nN) to drill into' },
+          },
+          oneOf: [{ required: ['file'] }, { required: ['ref'] }],
+          additionalProperties: false,
+        },
+      },
+      ['target'],
+    ),
+  },
+  find: {
+    op: 'find',
+    verb: 'find',
+    category: 'core',
+    targetShape: 'kind-query',
+    schema: obj(
+      'find',
+      {
+        sessionId,
+        kind: {
+          type: 'string',
+          enum: ['class', 'function', 'interface', 'enum', 'type', 'variable', 'import', 'export'],
+        },
+        query: {
+          type: 'object',
+          description: 'Optional structural filter, e.g. { pattern, name, ... }',
+          additionalProperties: true,
+        },
+      },
+      ['kind'],
+    ),
+  },
+  diff: {
+    op: 'diff',
+    verb: 'diff',
+    category: 'core',
+    targetShape: 'optional-file',
+    schema: obj('diff', {
+      sessionId,
+      file: { ...filePath, description: 'Limit diff to one file (omit for every dirty file)' },
+    }),
+  },
+  save: {
+    op: 'save',
+    verb: 'save',
+    category: 'core',
+    targetShape: 'optional-file',
+    schema: obj('save', {
+      sessionId,
+      file: { ...filePath, description: 'Save just this file (omit to flush every dirty file)' },
+    }),
+  },
+  reload: {
+    op: 'reload',
+    verb: 'reload',
+    category: 'core',
+    targetShape: 'file',
+    schema: obj('reload', { sessionId, file: filePath }, ['file']),
+  },
+  listFiles: {
+    op: 'listFiles',
+    verb: 'list',
+    category: 'core',
+    targetShape: 'optional-glob',
+    schema: obj('listFiles', {
+      sessionId,
+      glob: { type: 'string', description: 'Optional glob to narrow the listed files' },
+    }),
+  },
+};

--- a/packages/cli/src/session/session.spec.ts
+++ b/packages/cli/src/session/session.spec.ts
@@ -4,6 +4,8 @@ import { join } from 'node:path';
 
 import { getActiveProject, resetActiveProject } from '@mutates/core';
 
+import { ErrorCode } from '../proto/error-codes';
+import { RpcError } from '../proto/jsonrpc';
 import { Session } from './session';
 
 describe('Session', () => {
@@ -58,5 +60,73 @@ describe('Session', () => {
       });
       expect(getActiveProject()).toBe(outer.project);
     });
+  });
+
+  it('loads files from an explicit leaf tsconfig', () => {
+    const tsconfigPath = join(root, 'tsconfig.lib.json');
+    writeFileSync(
+      tsconfigPath,
+      JSON.stringify({
+        compilerOptions: { target: 'ES2022', module: 'commonjs' },
+        include: ['src/**/*'],
+      }),
+    );
+    const session = new Session({ root, tsconfig: tsconfigPath });
+    expect(session.tsconfig).toBe(tsconfigPath);
+    expect(session.project.getSourceFiles().length).toBeGreaterThan(0);
+  });
+
+  it('rejects a solution-style tsconfig with INVALID_INPUT', () => {
+    // Solution-style: empty files/include, has references → ts-morph would
+    // silently load 0 source files.
+    const tsconfigPath = join(root, 'tsconfig.json');
+    writeFileSync(
+      tsconfigPath,
+      // JSONC: leading comment + trailing comma to exercise the
+      // ts.parseConfigFileTextToJson path.
+      [
+        '// solution-style tsconfig',
+        '{',
+        '  "files": [],',
+        '  "references": [{ "path": "./packages/foo" }],',
+        '}',
+      ].join('\n'),
+    );
+    let err: unknown;
+    try {
+      // eslint-disable-next-line no-new
+      new Session({ root });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(RpcError);
+    expect((err as RpcError).code).toBe(ErrorCode.InvalidInput);
+    expect((err as RpcError).message).toMatch(/solution-style/);
+  });
+
+  it('rejects a missing --tsconfig with INVALID_INPUT', () => {
+    let err: unknown;
+    try {
+      // eslint-disable-next-line no-new
+      new Session({ root, tsconfig: join(root, 'does-not-exist.json') });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(RpcError);
+    expect((err as RpcError).code).toBe(ErrorCode.InvalidInput);
+    expect((err as RpcError).message).toMatch(/tsconfig not found/);
+  });
+
+  it('fallback glob excludes node_modules and dist', () => {
+    mkdirSync(join(root, 'node_modules/some-pkg'), { recursive: true });
+    writeFileSync(join(root, 'node_modules/some-pkg/index.ts'), 'export const x = 1;\n');
+    mkdirSync(join(root, 'dist'), { recursive: true });
+    writeFileSync(join(root, 'dist/a.ts'), 'export const y = 1;\n');
+
+    const session = new Session({ root });
+    const paths = session.project.getSourceFiles().map((sf) => sf.getFilePath());
+    expect(paths.some((p) => p.includes('/node_modules/'))).toBe(false);
+    expect(paths.some((p) => p.includes('/dist/'))).toBe(false);
+    expect(paths.some((p) => p.endsWith('src/a.ts'))).toBe(true);
   });
 });

--- a/packages/cli/src/session/session.ts
+++ b/packages/cli/src/session/session.ts
@@ -1,15 +1,24 @@
 import { randomUUID } from 'node:crypto';
-import { existsSync, statSync } from 'node:fs';
-import { join, resolve as resolvePath } from 'node:path';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { isAbsolute, join, resolve as resolvePath } from 'node:path';
 
 import { Project, resetActiveProject, setActiveProject, type SourceFile } from '@mutates/core';
 
+import { ErrorCode } from '../proto/error-codes';
+import { RpcError } from '../proto/jsonrpc';
 import { FileStatCache } from './file-stat-cache';
 import { RefTable } from './ref-table';
 
 export interface SessionOptions {
   /** Absolute or relative project root. */
   root: string;
+  /**
+   * Optional path to a tsconfig (absolute or relative to `root`). When
+   * provided, overrides the default lookup of `<root>/tsconfig.json`.
+   * A solution-style tsconfig (empty `files`/`include` with non-empty
+   * `references`) is rejected — pass a leaf tsconfig instead.
+   */
+  tsconfig?: string;
 }
 
 interface RecordedText {
@@ -41,15 +50,48 @@ export class Session {
     this.root = resolvePath(opts.root);
     this.openedAt = Date.now();
 
-    const tsconfigCandidate = join(this.root, 'tsconfig.json');
-    this.tsconfig = existsSync(tsconfigCandidate) ? tsconfigCandidate : null;
+    if (opts.tsconfig !== undefined) {
+      const resolved = isAbsolute(opts.tsconfig)
+        ? opts.tsconfig
+        : resolvePath(this.root, opts.tsconfig);
+      if (!existsSync(resolved)) {
+        throw new RpcError(ErrorCode.InvalidInput, `session: tsconfig not found: ${resolved}`, {
+          tsconfig: resolved,
+        });
+      }
+      this.tsconfig = resolved;
+    } else {
+      const candidate = join(this.root, 'tsconfig.json');
+      this.tsconfig = existsSync(candidate) ? candidate : null;
+    }
 
     this.project = this.tsconfig ? new Project({ tsConfigFilePath: this.tsconfig }) : new Project();
 
-    if (!this.tsconfig) {
+    if (this.tsconfig) {
+      // ts-morph silently accepts solution-style tsconfigs (empty
+      // files/include with references) and loads 0 source files. Detect
+      // that explicitly and surface a useful error instead of a silently
+      // empty session.
+      if (this.project.getSourceFiles().length === 0 && isSolutionStyle(this.tsconfig)) {
+        throw new RpcError(
+          ErrorCode.InvalidInput,
+          `session: tsconfig is solution-style (empty files/include, has references). Pass --tsconfig pointing at a leaf tsconfig (e.g. tsconfig.lib.json) or a --root with no tsconfig.json.`,
+          { tsconfig: this.tsconfig },
+        );
+      }
+    } else {
       // No tsconfig — lazily pick up any TS sources under root so a
       // bare-directory project still has source files to operate on.
-      this.project.addSourceFilesAtPaths(join(this.root, '**/*.{ts,tsx}'));
+      // Skip vendor/build/scratch directories so the session doesn't
+      // balloon to thousands of irrelevant .d.ts files.
+      this.project.addSourceFilesAtPaths([
+        join(this.root, '**/*.{ts,tsx}'),
+        `!${join(this.root, '**/node_modules/**')}`,
+        `!${join(this.root, '**/dist/**')}`,
+        `!${join(this.root, '**/.git/**')}`,
+        `!${join(this.root, '**/tmp/**')}`,
+        `!${join(this.root, '**/coverage/**')}`,
+      ]);
     }
 
     this.refs = new RefTable();
@@ -119,4 +161,38 @@ export class Session {
     }
     return dirty;
   }
+}
+
+/**
+ * Heuristic: a tsconfig is "solution-style" when it declares no files
+ * itself (both `files` and `include` absent or empty) but lists project
+ * `references`. Such configs delegate compilation to referenced
+ * sub-projects and load 0 source files in ts-morph's default mode.
+ */
+function isSolutionStyle(tsconfigPath: string): boolean {
+  try {
+    const raw = readFileSync(tsconfigPath, 'utf8');
+    const stripped = stripJsonComments(raw);
+    const cfg = JSON.parse(stripped) as {
+      files?: unknown[];
+      include?: unknown[];
+      references?: unknown[];
+    };
+    const noFiles = !Array.isArray(cfg.files) || cfg.files.length === 0;
+    const noInclude = !Array.isArray(cfg.include) || cfg.include.length === 0;
+    const hasReferences = Array.isArray(cfg.references) && cfg.references.length > 0;
+    return noFiles && noInclude && hasReferences;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Minimal JSON-with-comments stripper for tsconfig files. Handles
+ * `//` line comments and `/* … *\/` blocks. Not robust against
+ * comments-inside-strings, but tsconfigs in practice don't contain
+ * those.
+ */
+function stripJsonComments(input: string): string {
+  return input.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
 }

--- a/packages/cli/src/session/session.ts
+++ b/packages/cli/src/session/session.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from 'node:crypto';
 import { existsSync, readFileSync, statSync } from 'node:fs';
-import { isAbsolute, join, resolve as resolvePath } from 'node:path';
+import { join, resolve as resolvePath } from 'node:path';
 
-import { Project, resetActiveProject, setActiveProject, type SourceFile } from '@mutates/core';
+import { Project, resetActiveProject, setActiveProject, ts, type SourceFile } from '@mutates/core';
 
 import { ErrorCode } from '../proto/error-codes';
 import { RpcError } from '../proto/jsonrpc';
@@ -13,10 +13,11 @@ export interface SessionOptions {
   /** Absolute or relative project root. */
   root: string;
   /**
-   * Optional path to a tsconfig (absolute or relative to `root`). When
-   * provided, overrides the default lookup of `<root>/tsconfig.json`.
-   * A solution-style tsconfig (empty `files`/`include` with non-empty
-   * `references`) is rejected — pass a leaf tsconfig instead.
+   * Optional absolute path to a tsconfig. When provided, overrides the
+   * default lookup of `<root>/tsconfig.json`. A solution-style tsconfig
+   * (empty `files`/`include` with non-empty `references`) is rejected —
+   * pass a leaf tsconfig instead. Callers (CLI / RPC) are expected to
+   * resolve any relative path before constructing a Session.
    */
   tsconfig?: string;
 }
@@ -51,15 +52,16 @@ export class Session {
     this.openedAt = Date.now();
 
     if (opts.tsconfig !== undefined) {
-      const resolved = isAbsolute(opts.tsconfig)
-        ? opts.tsconfig
-        : resolvePath(this.root, opts.tsconfig);
-      if (!existsSync(resolved)) {
-        throw new RpcError(ErrorCode.InvalidInput, `session: tsconfig not found: ${resolved}`, {
-          tsconfig: resolved,
-        });
+      if (!existsSync(opts.tsconfig)) {
+        throw new RpcError(
+          ErrorCode.InvalidInput,
+          `session: tsconfig not found: ${opts.tsconfig}`,
+          {
+            tsconfig: opts.tsconfig,
+          },
+        );
       }
-      this.tsconfig = resolved;
+      this.tsconfig = opts.tsconfig;
     } else {
       const candidate = join(this.root, 'tsconfig.json');
       this.tsconfig = existsSync(candidate) ? candidate : null;
@@ -88,6 +90,10 @@ export class Session {
         join(this.root, '**/*.{ts,tsx}'),
         `!${join(this.root, '**/node_modules/**')}`,
         `!${join(this.root, '**/dist/**')}`,
+        `!${join(this.root, '**/build/**')}`,
+        `!${join(this.root, '**/out/**')}`,
+        `!${join(this.root, '**/.next/**')}`,
+        `!${join(this.root, '**/.nx/**')}`,
         `!${join(this.root, '**/.git/**')}`,
         `!${join(this.root, '**/tmp/**')}`,
         `!${join(this.root, '**/coverage/**')}`,
@@ -168,12 +174,16 @@ export class Session {
  * itself (both `files` and `include` absent or empty) but lists project
  * `references`. Such configs delegate compilation to referenced
  * sub-projects and load 0 source files in ts-morph's default mode.
+ *
+ * Uses `ts.parseConfigFileTextToJson` so JSONC comments and trailing
+ * commas are handled the same way `tsc` would handle them.
  */
 function isSolutionStyle(tsconfigPath: string): boolean {
   try {
     const raw = readFileSync(tsconfigPath, 'utf8');
-    const stripped = stripJsonComments(raw);
-    const cfg = JSON.parse(stripped) as {
+    const parsed = ts.parseConfigFileTextToJson(tsconfigPath, raw);
+    if (parsed.error || !parsed.config) return false;
+    const cfg = parsed.config as {
       files?: unknown[];
       include?: unknown[];
       references?: unknown[];
@@ -185,14 +195,4 @@ function isSolutionStyle(tsconfigPath: string): boolean {
   } catch {
     return false;
   }
-}
-
-/**
- * Minimal JSON-with-comments stripper for tsconfig files. Handles
- * `//` line comments and `/* … *\/` blocks. Not robust against
- * comments-inside-strings, but tsconfigs in practice don't contain
- * those.
- */
-function stripJsonComments(input: string): string {
-  return input.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export * from './lib/params';
 export * from './lib/project';
 export * from './lib/properties';
 export * from './lib/source-file';
+export * from './lib/type-aliases';
 export * from './lib/utils';
 export * from './lib/variables';
 export * from 'ts-morph';

--- a/packages/core/src/lib/source-file/get-source-files.ts
+++ b/packages/core/src/lib/source-file/get-source-files.ts
@@ -5,14 +5,12 @@ import { Pattern } from '../utils';
 
 export function getSourceFiles(pattern?: Pattern): SourceFile[] {
   const project = getActiveProject();
-  let files: SourceFile[];
-  if (pattern === undefined) {
-    files = project.getSourceFiles();
-  } else if (typeof pattern === 'string') {
-    files = project.getSourceFiles(pattern);
-  } else {
-    files = project.getSourceFiles(pattern as readonly string[]);
-  }
+  const files =
+    pattern === undefined
+      ? project.getSourceFiles()
+      : typeof pattern === 'string'
+        ? project.getSourceFiles(pattern)
+        : project.getSourceFiles(pattern as readonly string[]);
   return files.filter((file) => !file.isFromExternalLibrary());
 }
 

--- a/packages/core/src/lib/source-file/get-source-files.ts
+++ b/packages/core/src/lib/source-file/get-source-files.ts
@@ -4,9 +4,16 @@ import { getActiveProject } from '../project';
 import { Pattern } from '../utils';
 
 export function getSourceFiles(pattern?: Pattern): SourceFile[] {
-  return getActiveProject()
-    .getSourceFiles(pattern as string)
-    .filter((file) => !file.isFromExternalLibrary());
+  const project = getActiveProject();
+  let files: SourceFile[];
+  if (pattern === undefined) {
+    files = project.getSourceFiles();
+  } else if (typeof pattern === 'string') {
+    files = project.getSourceFiles(pattern);
+  } else {
+    files = project.getSourceFiles(pattern as readonly string[]);
+  }
+  return files.filter((file) => !file.isFromExternalLibrary());
 }
 
 export function getSourceFile(filePath: string): SourceFile | null {

--- a/packages/core/src/lib/utils/helpers/get-declaration-getter.ts
+++ b/packages/core/src/lib/utils/helpers/get-declaration-getter.ts
@@ -7,13 +7,13 @@ import { matchQuery } from './match-query';
 export function getDeclarationGetter<
   Declaration extends StructuredStatement<Declaration>,
   Structure extends StructureType<Declaration> = StructureType<Declaration>,
->(getFn: (pattern: Pattern) => Declaration[]) {
+>(getFn: (pattern?: Pattern) => Declaration[]) {
   return function getDeclaration(
     query?: Query<Omit<Structure, 'kind'>> & { pattern?: Pattern },
   ): Declaration[] {
     const { pattern, ...rest } = query ?? {};
 
-    return getFn(pattern ?? '**/*').filter((declaration) =>
+    return getFn(pattern).filter((declaration) =>
       // TODO: refactor it to support new typings
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore


### PR DESCRIPTION
## Summary

Batch fix for DX issues surfaced while driving `mutates` against this repo. One bundled PR; commits split per issue.

- `--tsconfig` flag on `mutates open` + hard error on solution-style tsconfig (was: silently empty session)
- `find <kind>` without `--query` now returns every loaded source file (was: `[]` because the default `**/*` glob was resolved relative to cwd)
- `find type` now actually works — `getTypeAliases` exported from `@mutates/core` and wired into FINDERS (type-aliases also picked up by codegen as a bonus)
- Hand-written core ops (`snapshot`, `find`, `diff`, `save`, `reload`, `listFiles`, `session.*`) now expose JSON Schema via `mutates schema --op <name>` (was: `unknown op`)
- `close --all` returns `noop: true` and prints `no live sessions for <root>` in text mode when there's nothing to close
- Fallback glob in tsconfig-less sessions excludes `node_modules`, `dist`, `.git`, `tmp`, `coverage` (was: pulled ~10k `.d.ts` files)
- `skills/core.md` refreshed: documents `--tsconfig`, solution-style failure, `noop`, type-aliases, and fixes two stale bits (`sessions list` payload, `open` response example) that predated this PR

### Breaking change

Commit `e7df167` removes the redundant inner `ok/result` envelope from generated `op` handlers. Callers reading `result.result.…` must read `result.…` directly. Final shape of `mutates op <name>` is:

```
{ "ok": true, "result": <op return>, "mutated": [<paths>] }
```

instead of the previous double-wrapped:

```
{ "ok": true, "result": { "ok": true, "result": <op return> }, "mutated": [<paths>] }
```

## Test plan

- [x] `nx run-many -t build,test,lint --projects=core,cli` — 99/99 core, 136/136 cli, 0 lint errors
- [x] `mutates open --tsconfig tsconfig.lib.json --root packages/core` → session with 104 files, tsconfig path echoed
- [x] `mutates open --root packages/core` → `INVALID_INPUT` with actionable message
- [x] `mutates find function --json` → 68 results (was 0)
- [x] `mutates find type --json` → 10 results
- [x] `mutates schema --op snapshot --json` → valid JSON Schema
- [x] `mutates edit-functions --ref @nX --json '{"name":"foo"}'` → single-layer envelope
- [x] `mutates close --all` against empty daemon → `{"closed":[],"noop":true}` / `no live sessions for <root>`
- [x] Session rooted at repo root → 0 files under `node_modules`/`dist`